### PR TITLE
Fix subchannel start address calculation in SSTC

### DIFF
--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -247,7 +247,7 @@ void Receiver::assemble(EdiDecoder::ReceivedTagPacket&& tag_data)
 
         // STC
         for (const auto& subch : m_subchannels) {
-            eti.push_back( (subch.scid << 2) | (subch.sad & 0x300) );
+            eti.push_back( (subch.scid << 2) | ((subch.sad & 0x300) >> 8) );
             eti.push_back( subch.sad & 0xff );
             eti.push_back( (subch.tpl << 2) | ((subch.stl() & 0x300) >> 8) );
             eti.push_back( subch.stl() & 0xff );


### PR DESCRIPTION
Without this fix, the wrong subchannel start address is provided in the SSTC, causing issues for ensembles with more than 4 subchannels. This fixes issue #4.